### PR TITLE
Pass Content to components so that static content can be parsed.

### DIFF
--- a/.changeset/hungry-islands-shave.md
+++ b/.changeset/hungry-islands-shave.md
@@ -1,0 +1,5 @@
+---
+"rich-text-svelte-renderer": patch
+---
+
+Pass content to component so that static content can be parsed for things like slugifying headings

--- a/src/lib/DefaultElement.svelte
+++ b/src/lib/DefaultElement.svelte
@@ -2,13 +2,15 @@
 	import type { HTMLAttributes } from 'svelte/elements';
 	import type { NodeRendererType } from './types';
 	import { defaultElements } from './defaultElements';
+	import type { ElementNode } from '@graphcms/rich-text-types';
 
 	interface Props extends HTMLAttributes<HTMLElement> {
 		nodeRendererType: keyof NodeRendererType;
 		children?: import('svelte').Snippet;
+		content?: ElementNode[];
 	}
 
-	let { nodeRendererType, children, ...rest }: Props = $props();
+	let { nodeRendererType, children, content, ...rest }: Props = $props();
 	let Component = $derived(defaultElements[nodeRendererType]);
 </script>
 
@@ -19,7 +21,7 @@
 		{@render children?.()}
 	</svelte:element>
 {:else}
-	<Component {...rest}>
+	<Component {content} {...rest}>
 		{@render children?.()}
 	</Component>
 {/if}

--- a/src/lib/RenderElement.svelte
+++ b/src/lib/RenderElement.svelte
@@ -96,7 +96,7 @@
 			<RenderElements {content} {renderers} {references} parent={element} />
 		</svelte:element>
 	{:else if Component}
-		<Component {nodeRendererType} {...referenceValues} {...rest}>
+		<Component {nodeRendererType} {content} {...referenceValues} {...rest}>
 			<RenderElements {content} {renderers} {references} parent={element} />
 		</Component>
 	{/if}


### PR DESCRIPTION
Currently we do not pass any of the child content to components. This makes it impossible to do things like slugify headings. Child content will now be passed through the `content` prop. 