### PR TITLE
Use encodeURI instead of escapeHTML since the src is url

### DIFF
--- a/.changeset/cool-rivers-write.md
+++ b/.changeset/cool-rivers-write.md
@@ -1,0 +1,5 @@
+---
+'rich-text-svelte-renderer': patch
+---
+
+iFrame src issue: replaced escapeHTML with encodeURI

--- a/src/lib/Elements/IFrame.svelte
+++ b/src/lib/Elements/IFrame.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { escapeHTML } from 'es-escape-html';
-
 	interface Props {
 		url?: string;
 		title?: string;
@@ -23,7 +21,7 @@
 		style:left="0"
 		style:width="100%"
 		style:height="100%"
-		src={escapeHTML(url)}
+		src={encodeURI(url)}
 		loading="lazy"
 		allow="fullscreen"
 		frameBorder="0"


### PR DESCRIPTION
Issue: When `url` prop contains ampersand, `escapeHTML` encodes it to `&amp;` and pass it to `src` of `iFrame`. It caused the URL to not work properly.

Fix: Replaced `escapeHTML()` with `encodeURI()`